### PR TITLE
Updating webbit for Chrome 16 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.webbitserver</groupId>
       <artifactId>webbit</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Chrome 16 implements the latest version of the web sockets spec which is not compatible with the version implemented in webbit 0.2.0. Webbit 0.3.0 resolves this.
