### PR TITLE
added keepalive options

### DIFF
--- a/src/main/java/org/codefirst/jenkins/wsnotifier/PingTimerThread.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/PingTimerThread.java
@@ -1,0 +1,27 @@
+package org.codefirst.jenkins.wsnotifier;
+
+public class PingTimerThread extends Thread {
+	private boolean run = true;
+	private int interval;
+	
+	public PingTimerThread(int interval) {
+		this.interval = interval;
+		// autostart
+		start();
+	}
+	
+	public void run() {
+		while (run) {
+    		try {
+				Thread.sleep(interval * 1000);
+	    		WsServer.ping();
+			} catch (InterruptedException e) {
+			}
+		}
+	}
+	
+	public void terminate() {
+		run = false;
+		interrupt();
+	}
+}

--- a/src/main/java/org/codefirst/jenkins/wsnotifier/WsNotifier.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/WsNotifier.java
@@ -35,8 +35,11 @@ public class WsNotifier extends Notifier {
     @Extension // This indicates to Jenkins that this is an implementation of an extension point.
     public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         private int port = 8081;
+        private int pingInterval = 20;
 
         public int port(){ return port; }
+        public boolean keepalive(){ return pingInterval >= 0; }
+        public int pingInterval(){ if (keepalive()) return pingInterval; else return 20; }
 
         public DescriptorImpl() {
             load();
@@ -63,7 +66,14 @@ public class WsNotifier extends Notifier {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        	System.out.println(formData);
             port = formData.getInt("port");
+            if (formData.has("keepalive")) {
+            	JSONObject keepalive = formData.getJSONObject("keepalive");
+                pingInterval = keepalive.getInt("pingInterval");
+            } else {
+            	pingInterval = -1;
+            }
             save();
             WsServer.reset(port);
             return super.configure(req,formData);

--- a/src/main/java/org/codefirst/jenkins/wsnotifier/WsNotifier.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/WsNotifier.java
@@ -75,7 +75,7 @@ public class WsNotifier extends Notifier {
             	pingInterval = -1;
             }
             save();
-            WsServer.reset(port);
+            WsServer.reset(port, pingInterval);
             return super.configure(req,formData);
         }
     }

--- a/src/main/java/org/codefirst/jenkins/wsnotifier/WsNotifier.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/WsNotifier.java
@@ -1,16 +1,24 @@
 package org.codefirst.jenkins.wsnotifier;
-import hudson.Launcher;
 import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
-import hudson.model.*;
-import hudson.tasks.*;
-import net.sf.json.JSONObject;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.QueryParameter;
+
+import java.io.IOException;
 
 import javax.servlet.ServletException;
-import java.io.IOException;
+
+import net.sf.json.JSONObject;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 public class WsNotifier extends Notifier {
     @DataBoundConstructor
@@ -66,7 +74,6 @@ public class WsNotifier extends Notifier {
 
         @Override
         public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
-        	System.out.println(formData);
             port = formData.getInt("port");
             if (formData.has("keepalive")) {
             	JSONObject keepalive = formData.getJSONObject("keepalive");

--- a/src/main/java/org/codefirst/jenkins/wsnotifier/WsServer.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/WsServer.java
@@ -13,31 +13,20 @@ public class WsServer implements WebSocketHandler {
     private static CopyOnWriteArrayList<WebSocketConnection> connections =
         new CopyOnWriteArrayList<WebSocketConnection>();
 
-    private static Thread pingTimer = new Thread(){
-    	public void run(){
-    		while (true) {
-	    		try {
-					Thread.sleep(20000);
-		    		WsServer.ping();
-				} catch (InterruptedException e) {
-				}
-    		}
-    	}
-    };
+    private static PingTimerThread pingTimer;
     
     @Initializer(before=InitMilestone.COMPLETED)
     public static void init() {
         WsNotifier.DescriptorImpl desc =
             Hudson.getInstance().getDescriptorByType(WsNotifier.DescriptorImpl.class);
         if(desc != null) {
-            reset(desc.port());
+            reset(desc.port(), desc.keepalive() ? desc.pingInterval() : -1);
         }else{
-            reset(8081);
+            reset(8081, 20);
         }
-        pingTimer.start();
     }
 
-    synchronized public static void reset(int port) {
+    synchronized public static void reset(int port, int pingInterval) {
         System.out.println("stopping web server");
         if(webServer != null){
             for(WebSocketConnection con : connections){
@@ -46,10 +35,12 @@ public class WsServer implements WebSocketHandler {
             connections.clear();
             webServer.stop();
         }
+        if(pingTimer != null) pingTimer.terminate();
         System.out.println("start websocket server at " + port);
         webServer = WebServers.createWebServer(port)
             .add("/jenkins", new WsServer());
         webServer.start();
+        if (pingInterval > 0) pingTimer = new PingTimerThread(pingInterval);
     }
 
     static public void send(AbstractBuild build){
@@ -63,10 +54,13 @@ public class WsServer implements WebSocketHandler {
             con.send(json);
         }
         
-        pingTimer.interrupt();
+        // it's not necessary to send out a ping immediately or shortly after having send a client message.
+        // reset the ping timer to wait its full interval again after sending
+        if (pingTimer != null) pingTimer.interrupt();
     }
     
-    static private void ping(){
+    static protected void ping(){
+    	System.out.println("sending out pings");
     	for (WebSocketConnection con : connections) {
     		con.ping("ping".getBytes());
     	}

--- a/src/main/java/org/codefirst/jenkins/wsnotifier/WsServer.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/WsServer.java
@@ -1,12 +1,18 @@
 package org.codefirst.jenkins.wsnotifier;
 
-import hudson.init.Initializer;
 import hudson.init.InitMilestone;
+import hudson.init.Initializer;
 import hudson.model.AbstractBuild;
-import org.webbitserver.*;
+import hudson.model.Hudson;
+
 import java.util.concurrent.CopyOnWriteArrayList;
+
 import net.sf.json.JSONObject;
-import hudson.model.*;
+
+import org.webbitserver.WebServer;
+import org.webbitserver.WebServers;
+import org.webbitserver.WebSocketConnection;
+import org.webbitserver.WebSocketHandler;
 
 public class WsServer implements WebSocketHandler {
     private static WebServer webServer = null;
@@ -60,21 +66,17 @@ public class WsServer implements WebSocketHandler {
     }
     
     static protected void ping(){
-    	System.out.println("sending out pings");
     	for (WebSocketConnection con : connections) {
     		con.ping("ping".getBytes());
     	}
     }
 
     public void onOpen(WebSocketConnection connection) {
-        System.out.println("on open");
         connections.add(connection);
     }
 
     public void onClose(WebSocketConnection connection) {
-        System.out.println("on close");
         connections.remove(connection);
-
     }
 
     public void onMessage(WebSocketConnection connection, String message) {

--- a/src/main/resources/org/codefirst/jenkins/wsnotifier/WsNotifier/global.jelly
+++ b/src/main/resources/org/codefirst/jenkins/wsnotifier/WsNotifier/global.jelly
@@ -5,5 +5,10 @@
       description="Port number of Websocket server">
       <f:textbox default="${descriptor.port()}" />
     </f:entry>
+    <f:optionalBlock title="Enable Websocket pings to keep connections alive" field="keepalive" checked="${descriptor.keepalive()}">
+      <f:entry title="Ping interval" field="pingInterval">
+        <f:textbox default="${descriptor.pingInterval()}" />
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 </j:jelly>


### PR DESCRIPTION
hi folks,

my experience with websockets (not only in jenkins but in general) is that it's close to impossible to really tell whether or not the socket is still alive as long as there's no data being sent (this is due to routers, firewalls etc. that are usually timing out idle connections pretty fast).

i was trying to build an xfd out of a toy traffic light (with a raspberry pi inside) and i ran into exactly that problem: the socket would work in the beginning, and the device would display project status correctly as long as the project was active (i.e. people were committing and builds would be made). the next day however, the socket would be dead without the device being aware. the build results the device were displaying were stale.

luckily the designers of the websocket protocol were aware of the basic problem at hand and built a mechanism into the protocol to be able to check for socket availability: pings and pongs.

i took a look at the code of the plugin and did a few changes to hopefully fix that. the most important changes are:
- passive pong messages are now automatically sent out everytime a client sends a ping (this was ignored before, which might lead to unwanted disconnects, depending on the client lib)
- active ping messages are now enabled by default and are sent out to every connected client in 20s intervals. the interval can be configured, or be disabled completely on the jenkins settings page.

this allows both the client and the server to check for socket availability (the corresponding server timeout has not been implemented as of yet).

i am currently testing the modified plugin on our jenkins server, first results are good so far.
