### PR TITLE
Support new message format

### DIFF
--- a/src/main/java/org/codefirst/jenkins/wsnotifier/WsServer.java
+++ b/src/main/java/org/codefirst/jenkins/wsnotifier/WsServer.java
@@ -49,11 +49,19 @@ public class WsServer implements WebSocketHandler {
         if (pingInterval > 0) pingTimer = new PingTimerThread(pingInterval);
     }
 
-    static public void send(AbstractBuild build){
+    static public void send(AbstractBuild build, boolean useStatusFormat){
+        send(build, null, useStatusFormat);
+    }
+
+    static public void send(AbstractBuild build, String result, boolean useStatusFormat){
+        String statusName = useStatusFormat ? "status" : "result";
+        if (result == null){
+            result = build.getResult().toString();
+        }
         String json = new JSONObject()
             .element("project", build.getProject().getName())
             .element("number" , new Integer(build.getNumber()))
-            .element("result" , build.getResult().toString())
+            .element(statusName , result)
             .toString();
 
         for(WebSocketConnection con : connections){

--- a/src/main/resources/org/codefirst/jenkins/wsnotifier/WsNotifier/global.jelly
+++ b/src/main/resources/org/codefirst/jenkins/wsnotifier/WsNotifier/global.jelly
@@ -5,6 +5,10 @@
       description="Port number of Websocket server">
       <f:textbox default="${descriptor.port()}" />
     </f:entry>
+    <f:entry title="Use status format"
+      field="useStatusFormat">
+      <f:checkbox default="${descriptor.useStatusFormat()}" />
+    </f:entry>
     <f:optionalBlock title="Enable Websocket pings to keep connections alive" field="keepalive" checked="${descriptor.keepalive()}">
       <f:entry title="Ping interval" field="pingInterval">
         <f:textbox default="${descriptor.pingInterval()}" />


### PR DESCRIPTION
New message format has "status" property instead of "result" property.
This property provides the status of build including "build start".

For backward compatibility, START cannot be added to "result" property.
So I provide new message format.
